### PR TITLE
Update `libspelling` to tag `0.4.0`

### DIFF
--- a/so.libdb.dissent.yml
+++ b/so.libdb.dissent.yml
@@ -28,7 +28,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/libspelling.git
-        tag: 0.2.1
+        tag: 0.4.0
 
   - name: dissent
     buildsystem: simple


### PR DESCRIPTION
**NOTE:** Don't merge this before the new release of `gotk4-spelling`